### PR TITLE
Add jupytercon 2023 banner

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -4,7 +4,8 @@ import { XMarkIcon } from "@heroicons/react/20/solid";
 function JupyterConBanner() {
   // persist this banner in local storage
   const key = "jupytercon-banner";
-  const value = localStorage.getItem(key) || false;
+  const value =
+    (typeof window !== "undefined" && localStorage.getItem(key)) || false;
   const [close, setClose] = React.useState(value);
   if (close) return null;
   return (
@@ -57,8 +58,8 @@ function JupyterConBanner() {
           type="button"
           className="-m-3 p-3 focus-visible:outline-offset-[-4px]"
           onClick={() => {
-            localStorage.setItem(key, "true");
             setClose(true);
+            typeof window !== "undefined" && localStorage.setItem(key, "true");
           }}
         >
           <span className="sr-only">Dismiss</span>

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -43,7 +43,7 @@ function JupyterConBanner() {
       </svg>
       <p className="text-sm leading-6 text-gray-900">
         We are excited to give a talk at <b>JupyterCon 2023</b> on May 10-12,
-        see you in Paris!{" "}
+        2023. See you in Paris!{" "}
         <a
           href="https://www.jupytercon.com/"
           target="_blank"

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { XMarkIcon } from "@heroicons/react/20/solid";
+
+function JupyterConBanner() {
+  // persist this banner in local storage
+  const key = "jupytercon-banner";
+  const value = localStorage.getItem(key) || false;
+  const [close, setClose] = React.useState(value);
+  if (close) return null;
+  return (
+    <div className="z-10 mx-auto w-full p-0 relative isolate flex items-center gap-x-6 overflow-hidden bg-gray-50 py-2.5 px-6 sm:px-3.5 sm:before:flex-1">
+      <svg
+        viewBox="0 0 577 310"
+        aria-hidden="true"
+        className="absolute top-1/2 left-[max(-7rem,calc(50%-52rem))] -z-10 w-[36.0625rem] -translate-y-1/2 transform-gpu blur-2xl"
+      >
+        <path
+          id="558b8b01-4d09-4091-8be3-c5da192b7892"
+          fill="url(#4b688345-001e-47fa-aa7a-d561812ecf15)"
+          fillOpacity=".3"
+          d="m142.787 168.697-75.331 62.132L.016 88.702l142.771 79.995 135.671-111.9c-16.495 64.083-23.088 173.257 82.496 97.291C492.935 59.13 494.936-54.366 549.339 30.385c43.523 67.8 24.892 159.548 10.136 196.946l-128.493-95.28-36.628 177.599-251.567-140.953Z"
+        />
+        <defs>
+          <linearGradient
+            id="4b688345-001e-47fa-aa7a-d561812ecf15"
+            x1="614.778"
+            x2="-42.453"
+            y1="26.617"
+            y2="96.115"
+            gradientUnits="userSpaceOnUse"
+          >
+            <stop stopColor="#9089FC" />
+            <stop offset={1} stopColor="#FF80B5" />
+          </linearGradient>
+        </defs>
+      </svg>
+      <svg
+        viewBox="0 0 577 310"
+        aria-hidden="true"
+        className="absolute top-1/2 left-[max(45rem,calc(50%+8rem))] -z-10 w-[36.0625rem] -translate-y-1/2 transform-gpu blur-2xl"
+      >
+        <use href="#558b8b01-4d09-4091-8be3-c5da192b7892" />
+      </svg>
+      <p className="text-sm leading-6 text-gray-900">
+        We are excited to give a talk at <b>JupyterCon 2023</b> on May 10-12,
+        see you in Paris!{" "}
+        <a
+          href="https://www.jupytercon.com/"
+          target="_blank"
+          className="whitespace-nowrap font-semibold"
+        >
+          Learn more&nbsp;<span aria-hidden="true">&rarr;</span>
+        </a>
+      </p>
+      <div className="flex flex-1 justify-end">
+        <button
+          type="button"
+          className="-m-3 p-3 focus-visible:outline-offset-[-4px]"
+          onClick={() => {
+            localStorage.setItem(key, "true");
+            setClose(true);
+          }}
+        >
+          <span className="sr-only">Dismiss</span>
+          <XMarkIcon className="h-5 w-5 text-gray-900" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function Banner() {
+  return (
+    <>
+      <JupyterConBanner />
+    </>
+  );
+}

--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -73,9 +73,9 @@ export function Team() {
                 <p className="text-base leading-7 text-gray-600">
                   {person.role}
                 </p>
-                <p className="mt-6 text-base leading-7 text-gray-600">
+                <div className="mt-6 text-base leading-7 text-gray-600">
                   {person.bio}
-                </p>
+                </div>
               </div>
             </li>
           ))}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -52,3 +52,368 @@
   --ifm-color-primary-lighter: #bce0f6;
   --ifm-color-primary-lightest: #eff7fd;
 }
+
+/**
+ Many tailwindui components requires preflight to function properly. But the
+ preflight seems to be incompatible with Docusaurus in different ways. Thus,
+ we use a customized Tailwind Preflight:
+ 1. remove <a> styles
+ 2. remove svg styles
+ 3. remove h1-6 font-size
+ */
+
+/*
+1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
+2. Allow adding a border to an element by just adding a border-width. (https://github.com/tailwindcss/tailwindcss/pull/116)
+*/
+
+*,
+::before,
+::after {
+  box-sizing: border-box; /* 1 */
+  border-width: 0; /* 2 */
+  border-style: solid; /* 2 */
+  border-color: theme("borderColor.DEFAULT", currentColor); /* 2 */
+}
+
+::before,
+::after {
+  --tw-content: "";
+}
+
+/*
+1. Use a consistent sensible line-height in all browsers.
+2. Prevent adjustments of font size after orientation changes in iOS.
+3. Use a more readable tab size.
+4. Use the user's configured `sans` font-family by default.
+5. Use the user's configured `sans` font-feature-settings by default.
+*/
+
+html {
+  line-height: 1.5; /* 1 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+  -moz-tab-size: 4; /* 3 */
+  tab-size: 4; /* 3 */
+  font-family: theme(
+    "fontFamily.sans",
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    "Helvetica Neue",
+    Arial,
+    "Noto Sans",
+    sans-serif,
+    "Apple Color Emoji",
+    "Segoe UI Emoji",
+    "Segoe UI Symbol",
+    "Noto Color Emoji"
+  ); /* 4 */
+  font-feature-settings: theme(
+    "fontFamily.sans[1].fontFeatureSettings",
+    normal
+  ); /* 5 */
+}
+
+/*
+1. Remove the margin in all browsers.
+2. Inherit line-height from `html` so users can set them as a class directly on the `html` element.
+*/
+
+body {
+  margin: 0; /* 1 */
+  line-height: inherit; /* 2 */
+}
+
+/*
+1. Add the correct height in Firefox.
+2. Correct the inheritance of border color in Firefox. (https://bugzilla.mozilla.org/show_bug.cgi?id=190655)
+3. Ensure horizontal rules are visible by default.
+*/
+
+hr {
+  height: 0; /* 1 */
+  color: inherit; /* 2 */
+  border-top-width: 1px; /* 3 */
+}
+
+/*
+Add the correct text decoration in Chrome, Edge, and Safari.
+*/
+
+abbr:where([title]) {
+  text-decoration: underline dotted;
+}
+
+/*
+Add the correct font weight in Edge and Safari.
+*/
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/*
+1. Use the user's configured `mono` font family by default.
+2. Correct the odd `em` font sizing in all browsers.
+*/
+
+code,
+kbd,
+samp,
+pre {
+  font-family: theme(
+    "fontFamily.mono",
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    "Liberation Mono",
+    "Courier New",
+    monospace
+  ); /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/*
+Add the correct font size in all browsers.
+*/
+
+small {
+  font-size: 80%;
+}
+
+/*
+Prevent `sub` and `sup` elements from affecting the line height in all browsers.
+*/
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/*
+1. Remove text indentation from table contents in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=999088, https://bugs.webkit.org/show_bug.cgi?id=201297)
+2. Correct table border color inheritance in all Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=935729, https://bugs.webkit.org/show_bug.cgi?id=195016)
+3. Remove gaps between table borders by default.
+*/
+
+table {
+  text-indent: 0; /* 1 */
+  border-color: inherit; /* 2 */
+  border-collapse: collapse; /* 3 */
+}
+
+/*
+1. Change the font styles in all browsers.
+2. Remove the margin in Firefox and Safari.
+3. Remove default padding in all browsers.
+*/
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit; /* 1 */
+  font-size: 100%; /* 1 */
+  font-weight: inherit; /* 1 */
+  line-height: inherit; /* 1 */
+  color: inherit; /* 1 */
+  margin: 0; /* 2 */
+  padding: 0; /* 3 */
+}
+
+/*
+Remove the inheritance of text transform in Edge and Firefox.
+*/
+
+button,
+select {
+  text-transform: none;
+}
+
+/*
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Remove default button styles.
+*/
+
+button,
+[type="button"],
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button; /* 1 */
+  background-color: transparent; /* 2 */
+  background-image: none; /* 2 */
+}
+
+/*
+Use the modern Firefox focus style for all focusable elements.
+*/
+
+:-moz-focusring {
+  outline: auto;
+}
+
+/*
+Remove the additional `:invalid` styles in Firefox. (https://github.com/mozilla/gecko-dev/blob/2f9eacd9d3d995c937b4251a5557d95d494c9be1/layout/style/res/forms.css#L728-L737)
+*/
+
+:-moz-ui-invalid {
+  box-shadow: none;
+}
+
+/*
+Add the correct vertical alignment in Chrome and Firefox.
+*/
+
+progress {
+  vertical-align: baseline;
+}
+
+/*
+Correct the cursor style of increment and decrement buttons in Safari.
+*/
+
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/*
+1. Correct the odd appearance in Chrome and Safari.
+2. Correct the outline style in Safari.
+*/
+
+[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
+}
+
+/*
+Remove the inner padding in Chrome and Safari on macOS.
+*/
+
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/*
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Change font properties to `inherit` in Safari.
+*/
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
+}
+
+/*
+Add the correct display in Chrome and Safari.
+*/
+
+summary {
+  display: list-item;
+}
+
+/*
+Removes the default spacing and border for appropriate elements.
+*/
+
+blockquote,
+dl,
+dd,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+hr,
+figure,
+p,
+pre {
+  margin: 0;
+}
+
+fieldset {
+  margin: 0;
+  padding: 0;
+}
+
+legend {
+  padding: 0;
+}
+
+ol,
+ul,
+menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/*
+Prevent resizing textareas horizontally by default.
+*/
+
+textarea {
+  resize: vertical;
+}
+
+/*
+1. Reset the default placeholder opacity in Firefox. (https://github.com/tailwindlabs/tailwindcss/issues/3300)
+2. Set the default placeholder color to the user's configured gray 400 color.
+*/
+
+input::placeholder,
+textarea::placeholder {
+  opacity: 1; /* 1 */
+  color: theme("colors.gray.400", #9ca3af); /* 2 */
+}
+
+/*
+Set the default cursor for buttons.
+*/
+
+button,
+[role="button"] {
+  cursor: pointer;
+}
+
+/*
+Make sure disabled buttons don't get the pointer cursor.
+*/
+:disabled {
+  cursor: default;
+}
+
+/*
+Constrain images and videos to the parent width and preserve their intrinsic aspect ratio. (https://github.com/mozdevs/cssremedy/issues/14)
+*/
+
+img,
+video {
+  max-width: 100%;
+  height: auto;
+}
+
+/* Make elements with the HTML hidden attribute stay hidden by default */
+[hidden] {
+  display: none;
+}

--- a/src/theme/Layout/index.js
+++ b/src/theme/Layout/index.js
@@ -1,0 +1,12 @@
+import React from "react";
+import Layout from "@theme-original/Layout";
+import { Banner } from "../../components/Banner";
+
+export default function LayoutWrapper(props) {
+  return (
+    <>
+      <Banner />
+      <Layout {...props} />
+    </>
+  );
+}


### PR DESCRIPTION
Also added:
- [swizzle and wrap](https://docusaurus.io/docs/swizzling) the Layout component of docusaurus
- a customized [tailwindcss preflight](https://tailwindcss.com/docs/preflight)
- fix team page's "`<div>`-inside-`<p>`" error

The banner screenshot:

<img width="811" alt="Screenshot 2023-02-18 at 7 58 31 PM" src="https://user-images.githubusercontent.com/4576201/219864540-1b53caf8-16ef-4165-9da6-5b02f602809c.png">
